### PR TITLE
bug修复20240701byDoggingDog

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Char.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/Char.java
@@ -664,7 +664,8 @@ public abstract class Char extends Actor {
 		if (defender.buff( Hex.class) != null) defRoll *= 0.8f;
 
 		//雾剑祝福效果
-		if (attacker.buff(FogSword.ActBless.class) != null) {
+		// Change by DoggingDog on 2024-07-01
+		if (attacker.buff(FogSword.ActBless.class) != null && hero.belongings.weapon() instanceof FogSword) {
 			FogSword ks =(FogSword) hero.belongings.weapon;
 			defRoll *= 1 + (20 + (float) (ks.level() * 4) / 100);
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/TacticalThrowTalen4Battlemage.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/TacticalThrowTalen4Battlemage.java
@@ -16,6 +16,7 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.mobs.Mob;
 import com.shatteredpixel.shatteredpixeldungeon.custom.testmode.WandOfScanningBeam;
 import com.shatteredpixel.shatteredpixeldungeon.effects.CellEmitter;
 import com.shatteredpixel.shatteredpixeldungeon.effects.MagicMissile;
+import com.shatteredpixel.shatteredpixeldungeon.effects.SpellSprite;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.BloodParticle;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.CorrosionParticle;
 import com.shatteredpixel.shatteredpixeldungeon.items.rings.RingOfBenediction;
@@ -206,7 +207,13 @@ public class TacticalThrowTalen4Battlemage {
         } else if (wand instanceof WandOfScanningBeam) {
             // null
         } else if (wand instanceof WandOfMagicMissile) {
-            // null
+            SpellSprite.show(attacker, SpellSprite.CHARGE);
+            for (Wand.Charger c : attacker.buffs(Wand.Charger.class)){
+                if (!(c.wand() instanceof WandOfMagicMissile)){
+                    c.gainCharge(0.5f * procChanceMultiplier(attacker));
+                }
+            }
+
         }
     }
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/armor/Armor.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/armor/Armor.java
@@ -583,7 +583,9 @@ public class Armor extends EquipableItem {
 		int multi = RingOfKing.updateMultiplier(Dungeon.hero);
 		if( RingOfKing.curItem != null && RingOfKing.curItem.cursed )
 			multi = 1;
-		req = req + multi;
+		// 暂时这样吧，先把问题修了
+		if(hero.belongings.getItem(RingOfKing.class) != null)
+			req = req + multi;
 		if (masteryPotionBonus){
 			req -= 2;
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/Weapon.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/weapon/Weapon.java
@@ -244,7 +244,9 @@ abstract public class Weapon extends KindOfWeapon {
 		int multi = RingOfKing.updateMultiplier(hero);
 		if( RingOfKing.curItem != null && RingOfKing.curItem.cursed )
 			multi = 1;
-		req = req + multi;
+		// 暂时这样吧，先把问题修了
+		if(hero.belongings.getItem(RingOfKing.class) != null)
+			req = req + multi;
 		if (masteryPotionBonus){
 			req -= 2;
 		}


### PR DESCRIPTION
bug修复：战法天赋导致的力量需求+1
bug修复：降低雾剑可能导致的ClassCastException的概率
bug修复：修复战术投掷中的魔弹法杖灌注效果
//
bug fix:STRReq +1 since battlemage's talent
bug fix:decrease probability of ClassCastException since Fogsword 
bug fix:fix talent(war throw) if magestaff inj magic missile wand
