### PR TITLE
部分天赋重做，修复战术投掷灵壤效果

### DIFF
--- a/core/src/main/assets/messages/actors/actors_zh.properties
+++ b/core/src/main/assets/messages/actors/actors_zh.properties
@@ -680,6 +680,10 @@ actors.hero.talent.mystical_charge.desc=_+1：_当战斗法师用老魔杖近战
 actors.hero.talent.war_throw.title=战术投掷
 actors.hero.talent.war_throw.desc=_+1：_战斗法师的投掷武器能以_50%的效率_享受老魔杖的近战效果以及法杖的灌注效果\n\n_+2：_战斗法师的投掷武器能以_100%的效率_享受老魔杖的近战效果以及法杖的灌注效果\n\n_+3：_战斗法师的投掷武器能以_150%的效率_享受老魔杖的近战效果以及法杖的灌注效果
 
+actors.hero.tacticalthrowtalen4battlemage$rockarmor.name=灵壤护甲(战术)
+actors.hero.tacticalthrowtalen4battlemage$rockarmor.desc=也是灵壤护甲,可惜它并不能用于召唤守护者,剩余护甲量：%1$d。
+
+
 actors.hero.talent.desperate_power.title=绝望动能
 actors.hero.talent.desperate_power.desc=_+1：_从灵魂标记里获得的生命值随目标生命值的减少而提升，最多在其生命值低于12%吸血翻1.1倍\n\n_+2：_从灵魂标记里获得的生命值随目标生命值的减少而提升，最多在其生命值低于25%吸血翻1.3倍\n\n_+3：_从灵魂标记里获得的生命值随目标生命值的减少而提升，最多在其生命值低于37%吸血翻1.5倍\n\n_+4：_从灵魂标记里获得的生命值随目标生命值的减少而提升，最多在其生命值低于50%吸血翻1.9倍。
 
@@ -770,6 +774,10 @@ actors.hero.talent.bounty_hunter.desc=_+1：_被刺客用技能刺杀的敌人�
 
 actors.hero.talent.brace_yourself.title=严阵以待
 actors.hero.talent.brace_yourself.desc=_+1：_若刺客在隐身时保持不移动，则下一次攻击的额外伤害提高至25/50/80/110%。\n\n_+2：_若刺客在隐身时保持不移动，则下一次攻击的额外伤害提高至30/60/95/130%。\n\n_+3：_若刺客在隐身时保持不移动，则下一次攻击的额外伤害提高至35/70/110/150%。\n\n_+4：_若刺客在隐身时保持不移动，则下一次攻击的额外伤害提高至40/80/125/170%。\n\n注：原先为10/20/35/50%。
+
+actors.buffs.braceyourself.name=藏锋
+actors.buffs.braceyourself.desc=此时刺客正严阵以待，伺机而动，下一次刺杀的额外伤害将得到提升。
+
 actors.hero.talent.power_recycle.title=能量回收
 actors.hero.talent.power_recycle.desc=_+1：_刺客用技能刺杀敌人后，获得_4回合充能_效果。\n\n_+2：_除获得+1的增益外，刺客用技能刺杀敌人后，获得_2回合神器充能_效果。\n\n_+3：_除获得+1，+2的增益外，被刺客用技能刺杀的敌人，为刺客提供复_25_饥饿值。\n\n_+4：_+1，+2，+3的增益有_50%_的概率对非技能击杀也生效。
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/BraceYourself.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/BraceYourself.java
@@ -1,0 +1,50 @@
+package com.shatteredpixel.shatteredpixeldungeon.actors.buffs;
+
+import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
+import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Talent;
+import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
+import com.shatteredpixel.shatteredpixeldungeon.ui.BuffIndicator;
+import com.watabou.noosa.Image;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Preparation;
+
+
+/*
+    class BraceYourself
+        detach if mv or lose preparation buff
+    by: DoggingDog
+ */
+public class BraceYourself extends Buff{
+
+    {
+        type = buffType.POSITIVE;
+    }
+
+    public int pos = -1;
+
+    @Override
+    public boolean act() {
+        if (pos == -1) pos = target.pos;
+        if (pos != target.pos || Dungeon.hero.buff(Preparation.class)==null) {
+            detach();
+        } else {
+            spend(TICK);
+        }
+        return true;
+    }
+
+    @Override
+    public int icon() {
+        return BuffIndicator.WEAPON;
+    }
+
+    @Override
+    public void tintIcon(Image icon) {
+        icon.hardlight(1.9f, 2.4f, 3.25f);
+    }
+
+    @Override
+    public String desc() {
+        return Messages.get(this, "desc");
+    }
+
+}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Preparation.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/buffs/Preparation.java
@@ -118,7 +118,11 @@ public class Preparation extends Buff implements ActionIndicator.Action {
 				int newDmg = attacker.damageRoll();
 				if (newDmg > dmg) dmg = newDmg;
 			}
-			return Math.round(dmg * (1f + baseDmgBonus+braceYourselfExtraDmg()));
+			// Talent : brace_yourself
+			if(Dungeon.hero.buff(BraceYourself.class) != null)
+				return Math.round(dmg * (1f + baseDmgBonus+braceYourselfExtraDmg()));
+			else
+				return Math.round(dmg * (1f + baseDmgBonus));
 		}
 		
 		public static AttackLevel getLvl(int turnsInvis){
@@ -216,7 +220,11 @@ public class Preparation extends Buff implements ActionIndicator.Action {
 		String desc = Messages.get(this, "desc");
 		
 		AttackLevel lvl = AttackLevel.getLvl(turnsInvis);
-		float bdb=lvl.baseDmgBonus+ lvl.braceYourselfExtraDmg();
+		//Talent : brace_yourself
+		float bdb=lvl.baseDmgBonus;
+		if(Dungeon.hero.buff(BraceYourself.class)!=null)
+			bdb=lvl.baseDmgBonus+ lvl.braceYourselfExtraDmg();
+
 		desc += "\n\n" + Messages.get(this, "desc_dmg",
 				(int)(bdb*100),
 				(int)(lvl.KOThreshold()*100),

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/Hero.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/Hero.java
@@ -633,16 +633,34 @@ public class Hero extends Char {
 			if (shielding()>0)
 				dr+=Random.NormalIntRange(2,8);
 		if (hasTalent(Talent.DARK_ARMOR)) {
-			for (Item item : Dungeon.hero.belongings.backpack) {
-				if (item instanceof CloakOfShadows) {
-					if (item.isEquipped(this)) {
-						int em=((CloakOfShadows) item).emptyCharge();
-						int p=pointsInTalent(Talent.DARK_ARMOR);
-						float fl[]={-1f,0,0.5f,0.5f,1f},ce[]={-1f,1f,1f,1.5f,2f};
-						dr += Random.NormalIntRange(Math.round(fl[p]*em),Math.round(ce[p]*em));
-					}
-				}
+			// deprecated on 2024/07/07
+//			for (Item item : Dungeon.hero.belongings.backpack) {
+//				if (item instanceof CloakOfShadows) {
+//					if (item.isEquipped(this)) {
+//						int em=((CloakOfShadows) item).emptyCharge();
+//						int p=pointsInTalent(Talent.DARK_ARMOR);
+//						float fl[]={-1f,0,0.5f,0.5f,1f},ce[]={-1f,1f,1f,1.5f,2f};
+//						dr += Random.NormalIntRange(Math.round(fl[p]*em),Math.round(ce[p]*em));
+//					}
+//				}
+//			}
+
+			// Talent : grace_yourself
+			float fl[]={-1f,0,0.5f,0.5f,1f},ce[]={-1f,1f,1f,1.5f,2f};
+			int p=pointsInTalent(Talent.DARK_ARMOR);
+			int em=0;
+			if(belongings.misc instanceof CloakOfShadows){
+				em = ((CloakOfShadows) belongings.misc).emptyCharge();
+				dr += Random.NormalIntRange(Math.round(fl[p]*em),Math.round(ce[p]*em));
+			} else if (belongings.artifact instanceof CloakOfShadows) {
+				em = ((CloakOfShadows) belongings.artifact).emptyCharge();
+				dr += Random.NormalIntRange(Math.round(fl[p]*em),Math.round(ce[p]*em));
 			}
+			else {
+				// null
+			}
+
+
 		}
 		return dr;
 	}
@@ -1300,7 +1318,7 @@ public class Hero extends Char {
 			Buff.affect(this, HoldFast.class);
 		}
 		// Talent : BraceYourself
-		if(hasTalent(Talent.BRACE_YOURSELF)){
+		if(hasTalent(Talent.BRACE_YOURSELF) && buff(Preparation.class) != null){
 			Buff.affect(this, BraceYourself.class);
 		}
 		if (!fullRest) {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/Hero.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/Hero.java
@@ -43,6 +43,7 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Barkskin;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Barrier;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Berserk;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Bless;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.BraceYourself;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Burning;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.ChampionHero;
@@ -1298,6 +1299,10 @@ public class Hero extends Char {
 		if (hasTalent(Talent.HOLD_FAST)){
 			Buff.affect(this, HoldFast.class);
 		}
+		// Talent : BraceYourself
+		if(hasTalent(Talent.BRACE_YOURSELF)){
+			Buff.affect(this, BraceYourself.class);
+		}
 		if (!fullRest) {
 			if (sprite != null) {
 				sprite.showStatus(CharSprite.DEFAULT, Messages.get(this, "wait"));
@@ -1425,6 +1430,12 @@ public class Hero extends Char {
 		WandOfLivingEarth.RockArmor rockArmor = buff(WandOfLivingEarth.RockArmor.class);
 		if (rockArmor != null) {
 			damage = rockArmor.absorb(damage);
+		}
+
+		// Talent: WarThrow
+		TacticalThrowTalen4Battlemage.RockArmor rockArmor4WarThrow = buff(TacticalThrowTalen4Battlemage.RockArmor.class);
+		if(rockArmor4WarThrow != null){
+			damage = rockArmor4WarThrow.absorb(damage);
 		}
 		
 		return super.defenseProc( enemy, damage );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mob.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mob.java
@@ -76,6 +76,7 @@ import com.shatteredpixel.shatteredpixeldungeon.items.weapon.Weapon;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.enchantments.Lucky;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.Beecomb;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.EchoplexHammer;
+import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.Gloves;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.Rlyeh;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.Scythe;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.SufferingDagger;
@@ -682,20 +683,25 @@ public abstract class Mob extends Char {
 				int preHp=Dungeon.hero.HP;
 
 				if(hero.hasTalent(Talent.DESPERATE_POWER)){
-					switch (hero.pointsInTalent(Talent.DESPERATE_POWER)) {
-						case 1:
-							if (enemy.HP <= enemy.HT * 0.12) restoration = (int) (restoration * calculateMultiplier(1));
-							break;
-						case 2:
-							if (enemy.HP <= enemy.HT * 0.25) restoration = (int) (restoration * calculateMultiplier(2));
-							break;
-						case 3:
-							if (enemy.HP <= enemy.HT * 0.37) restoration = (int) (restoration * calculateMultiplier(3));
-							break;
-						case 4:
-							if (enemy.HP <= enemy.HT * 0.5)  restoration = (int) (restoration * calculateMultiplier(4));
-							break;
-					}
+					// deprecated on 2024/07/07
+//					switch (hero.pointsInTalent(Talent.DESPERATE_POWER)) {
+//						case 1:
+//							if (enemy.HP <= enemy.HT * 0.12) restoration = (int) (restoration * calculateMultiplier(1));
+//							break;
+//						case 2:
+//							if (enemy.HP <= enemy.HT * 0.25) restoration = (int) (restoration * calculateMultiplier(2));
+//							break;
+//						case 3:
+//							if (enemy.HP <= enemy.HT * 0.37) restoration = (int) (restoration * calculateMultiplier(3));
+//							break;
+//						case 4:
+//							if (enemy.HP <= enemy.HT * 0.5)  restoration = (int) (restoration * calculateMultiplier(4));
+//							break;
+//					}
+
+					// Talent : Desperate_Power
+					float mulRate =mul4DesperatePower(this);
+					restoration = (int)(restoration * mulRate);
 				}
 
 				Dungeon.hero.HP = (int) Math.ceil(Math.min(Dungeon.hero.HT, Dungeon.hero.HP + (restoration * 0.4f)));
@@ -1383,6 +1389,18 @@ public abstract class Mob extends Char {
 			}
 		}
 		heldAllies.clear();
+	}
+
+	public float mul4DesperatePower(Char enemy){
+		float lvDesPow = (float) hero.pointsInTalent(Talent.DESPERATE_POWER);
+		float stolenHpRate = ((float) this.HT-(float) this.HP)/(float) this.HT*2f;
+		float howMobDesperateThanBeforeMul = 1/(1-lvDesPow*0.125f) - 1;
+
+		stolenHpRate = stolenHpRate>1?1:stolenHpRate;
+		howMobDesperateThanBeforeMul *= stolenHpRate;
+		howMobDesperateThanBeforeMul = howMobDesperateThanBeforeMul>1?1:howMobDesperateThanBeforeMul;
+
+		return 1+howMobDesperateThanBeforeMul;
 	}
 	
 	public static void clearHeldAllies(){

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/ChaliceOfBlood.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/ChaliceOfBlood.java
@@ -26,6 +26,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Badges;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.MagicImmune;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
+import com.shatteredpixel.shatteredpixeldungeon.actors.hero.TacticalThrowTalen4Battlemage;
 import com.shatteredpixel.shatteredpixeldungeon.effects.particles.ShadowParticle;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.wands.WandOfLivingEarth;
@@ -104,6 +105,12 @@ public class ChaliceOfBlood extends Artifact {
 		WandOfLivingEarth.RockArmor rockArmor = hero.buff(WandOfLivingEarth.RockArmor.class);
 		if (rockArmor != null) {
 			damage = rockArmor.absorb(damage);
+		}
+
+		// Talent: WarThrow
+		TacticalThrowTalen4Battlemage.RockArmor rockArmor4WarThrow = hero.buff(TacticalThrowTalen4Battlemage.RockArmor.class);
+		if(rockArmor4WarThrow != null){
+			damage = rockArmor4WarThrow.absorb(damage);
 		}
 
 		damage -= hero.drRoll();


### PR DESCRIPTION
bug修复：修复战术投掷中灵壤法杖的效果与翻译
bug修复：刺客严阵以待天赋重做
bug修复：暗幕盔甲天赋重做
bug修复：绝望动能天赋重做

bug fix: fix translation and effect of LivingEarth wand if WarThrow work
bug fix: re-implement talent (brace yourself) of assassin
bug fix: re-implement talent grace_yourself
bug fix: re-implement talent desperate_power